### PR TITLE
Fix mysql length error when running locally

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace App\Providers;
-
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,8 +21,10 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
-    {
-        //
-    }
+
+
+     public function boot()
+     {
+         Schema::defaultStringLength(191);
+     }
 }


### PR DESCRIPTION
This PR fixes an error that happens when running locally connected to a mysql DB.

https://laravel-news.com/laravel-5-4-key-too-long-error